### PR TITLE
Fix for Android Crash on Launch

### DIFF
--- a/android-guide.md
+++ b/android-guide.md
@@ -47,6 +47,7 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:0.18.+"
+    compile "com.google.android.gms:play-services-auth:8.4.0" // <--- add this
     compile project(":react-native-google-signin") // <--- add this
 }
 


### PR DESCRIPTION
The app compiled just fine, but immediately after launch it would crash. I tracked it down to this error: `AndroidRuntime: java.lang.VerifyError: Rejecting class com.google.android.gms.internal.zzlb because it failed compile-time verification (declaration of 'com.google.android.gms.internal.zzlb' appears in /data/app/com.PROJECTNAME-2/base.apk)` and then eventually figured out that I needed to compile the Google Account Login API. Hopefully this minor change will save others significant debugging time.