### PR TITLE
Register for onActivityResult callback automatically

### DIFF
--- a/android-guide.md
+++ b/android-guide.md
@@ -56,7 +56,6 @@ apply plugin: 'com.google.gms.google-services' // <--- this should be the last l
 * Register Module (in MainActivity.java)
 
 ```java
-import co.apptailor.googlesignin.RNGoogleSigninModule; // <--- import
 import co.apptailor.googlesignin.RNGoogleSigninPackage;  // <--- import
 
 public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
@@ -68,15 +67,6 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
             new MainReactPackage(),
             new RNGoogleSigninPackage(this)); // <-- add this
     }
-
-  // add this method inside your activity class
-  @Override
-  public void onActivityResult(int requestCode, int resultCode, android.content.Intent data) {
-    if (requestCode == RNGoogleSigninModule.RC_SIGN_IN) {
-        RNGoogleSigninModule.onActivityResult(data);
-    }
-    super.onActivityResult(requestCode, resultCode, data);
-  }
 
   ......
 

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -49,8 +49,10 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule implements 
 
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
-        GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(intent);
-        handleSignInResult(result, false);
+        if (requestCode == RNGoogleSigninModule.RC_SIGN_IN) {
+            GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(intent);
+            handleSignInResult(result, false);
+        }
     }
 
     @Override

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
@@ -32,7 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
+public class RNGoogleSigninModule extends ReactContextBaseJavaModule implements ActivityEventListener {
     private Activity _activity;
     private GoogleApiClient _apiClient;
     private static ReactApplicationContext _context;
@@ -43,10 +44,12 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
         super(reactContext);
         _activity = activity;
         _context = reactContext;
+        reactContext.addActivityEventListener(this);
     }
 
-    public static void onActivityResult(Intent data) {
-        GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(data);
+    @Override
+    public void onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
+        GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(intent);
         handleSignInResult(result, false);
     }
 


### PR DESCRIPTION
Right now the install instructions suggest you add onActivityResult to your MainActivity manually to make signIn work. However, it's now possible to register with RN to receive this callback on your module. It's cleaner, easier and less error prone.