### PR TITLE
Adding Firebase dependency explicitly

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,6 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile "com.android.support:appcompat-v7:23.0.1"
     compile 'com.google.android.gms:play-services-auth:+'
+    compile 'com.google.firebase:firebase-core:+'
     compile "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
`apply plugin: 'com.google.gms.google-services'` selects the wrong version of firebase-core dependency.  In our app for example, `play-services-auth` is version 9.2.1 but the plugin uses 9.0.0 as a dependency.  This leads to clashes within dex.