### PR TITLE
Add onNewIntent method for RN 0.30

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -48,6 +48,9 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule implements 
     }
 
     @Override
+    public void onNewIntent(Intent intent) {}
+
+    @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
         if (requestCode == RNGoogleSigninModule.RC_SIGN_IN) {
             GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(intent);


### PR DESCRIPTION
React Native 0.30 introduces a [breaking change](https://github.com/facebook/react-native/commit/2fc0f4041ec836c1e1aef1f5d9c77b4f4aba4aae#commitcomment-18042380) for `ActivityEventListener`.
Classes that implements this interface must now override `onNewIntent`.

I add it no-op to have the build passing.

It's a *breaking change* for this library.