### PR TITLE
Do not abort on lint error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,10 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Apps that depend on react-native-google-signin will fail to build when using `./gradlew build` due to a lint error in react-native-google-signin.  This change fixes that.