### PR TITLE
Update iOS Setup Documentation

### DIFF
--- a/ios-guide.md
+++ b/ios-guide.md
@@ -9,7 +9,7 @@ Includes Google Sign-In SDK v4.0.0
 - make sure you have rnpm version >= 1.9.0
 - link the lib with `rnpm link react-native-google-signin`
 - Drag and drop the `ios/GoogleSdk` folder to your xcode project. (Make sure `Copy items if needed` **IS** ticked)
- - Alternatively, you can install this through cocoapods by adding `pod 'GoogleSignIn'` to your Podfile.
+ - Alternatively, you can install this through cocoapods by adding `pod 'GoogleSignIn'` to your Podfile if you are only building for iOS.
 
 #### Manual installation
 

--- a/ios-guide.md
+++ b/ios-guide.md
@@ -15,7 +15,7 @@ Includes Google Sign-In SDK v4.0.0
 
 - add `ios/RNGoogleSignin.xcodeproj` to your xcode project
 - In your project build phase -> `Link binary with libraries` step, add `libRNGoogleSignin.a`, `AddressBook.framework`, `SafariServices.framework`, `SystemConfiguration.framework` and `libz.tbd`
-- Drag and drop the `ios/GoogleSdk` folder to your xcode project. (Make sure `Copy items if needed` **IS** ticked) 
+- Drag and drop the `ios/GoogleSdk` folder to your xcode project. (Make sure `Copy items if needed` **IS** ticked)
 
 
 ### 2. Google project configuration
@@ -56,3 +56,14 @@ Inside AppDelegate.m
 }
 
 ````
+
+If you have multiple components listening for url open events, they can be combined into a single method like so:
+
+```
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+  // return YES once one succeeds
+  if ([RNGoogleSignin application:application openURL:url sourceApplication:sourceApplication annotation:annotation])
+    return YES;
+  return [RCTLinkingManager application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
+}
+```

--- a/ios-guide.md
+++ b/ios-guide.md
@@ -9,7 +9,7 @@ Includes Google Sign-In SDK v4.0.0
 - make sure you have rnpm version >= 1.9.0
 - link the lib with `rnpm link react-native-google-signin`
 - Drag and drop the `ios/GoogleSdk` folder to your xcode project. (Make sure `Copy items if needed` **IS** ticked)
-
+ - Alternatively, you can install this through cocoapods by adding `pod 'GoogleSignIn'` to your Podfile.
 
 #### Manual installation
 
@@ -57,7 +57,7 @@ Inside AppDelegate.m
 
 ````
 
-If you have multiple components listening for url open events, they can be combined into a single method like so:
+Only one `application:openURL` method can be defined, so if you have multiple things listening for open URL events (like multiple OAUTH providers), you must combine them into a single function like so:
 
 ```
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {


### PR DESCRIPTION
Closes #60 for you 👍 

The `application:openURL` method documentation stuff is basically straight out of #60, though I've confirmed that it appears to work. 

Cocoapods also appears to be a valid way to install the `GoogleSignIn` libraries, so if your project is already using it that might be a lot easier than drag-and-dropping the libraries provided by this module into the project. Let me know if you can think of any reasons why that wouldn't work, but it does appear to work fine for my project.

