### PR TITLE
iOS: use the top-most ViewController to present SFSafariViewController instead of using rootViewController

### DIFF
--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -110,8 +110,8 @@ RCT_EXPORT_METHOD(revokeAccess)
 }
 
 - (void) signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
-    UIViewController *rootViewController = [[[[UIApplication sharedApplication]delegate] window] rootViewController];
-    [rootViewController presentViewController:viewController animated:true completion:nil];
+    UIViewController *parent = [self topMostViewController];
+    [parent presentViewController:viewController animated:true completion:nil];
 }
 
 - (void) signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {
@@ -126,5 +126,14 @@ RCT_EXPORT_METHOD(revokeAccess)
                                       annotation:annotation];
 }
 
+#pragma mark - Internal Methods
+
+- (UIViewController *)topMostViewController {
+    UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+    return topController;
+}
 
 @end


### PR DESCRIPTION
Hi, I'm building an iOS framework using react native with your awesome module, which means my react view is presented by other view controller instead of root view controller. So when presenting `SFSafariViewController` by root view controller I got the error:

```
Attempt to present SFSafariViewController on ViewController whose view is not in the window hierarchy
```

This PR fixes this problem by finding the **top-most** view controller and use it to present `SFSafariViewController`. This method is borrowed from Facebook iOS SDK, for your reference: 
[this](https://github.com/facebook/facebook-ios-sdk/blob/sdk-version-4.14.0/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m#L329) and [this](https://github.com/facebook/facebook-ios-sdk/blob/sdk-version-4.14.0/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m#L621-L628).

Cheers!
