### PR TITLE
Allow GoogleSignIn installation via cocoapods

### DIFF
--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -243,6 +244,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This change adds one extra entry for the headers search path. This make it possible for the library build process to locate GoogleSignIn dependency installed via cocoapods as opposed to requiring developers to download and drop GoogleSdk into the project manually.