### PR TITLE
fix accessToken isn't returned in user object

### DIFF
--- a/GoogleSignin.android.js
+++ b/GoogleSignin.android.js
@@ -77,7 +77,7 @@ class GoogleSignin {
   currentUserAsync() {
     return new Promise((resolve, reject) => {
       const sucessCb = DeviceEventEmitter.addListener('RNGoogleSignInSilentSuccess', (user) => {
-        this._user = user;
+        this._user = {...user};
 
         RNGoogleSignin.getAccessToken(user).then((token) => {
           this._user.accessToken = token;
@@ -106,7 +106,7 @@ class GoogleSignin {
   signIn() {
     return new Promise((resolve, reject) => {
       const sucessCb = DeviceEventEmitter.addListener('RNGoogleSignInSuccess', (user) => {
-        this._user = user;
+        this._user = {...user};
         RNGoogleSignin.getAccessToken(user).then((token) => {
           this._user.accessToken = token;
           this._removeListeners(sucessCb, errorCb);


### PR DESCRIPTION
It looks like user object returned by DeviceEventEmitter.addListener is "immutable". The easy solution is create a copy and assign it to this._user property.