### PR TITLE
Android Build Tools & AppCompat update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,12 +17,12 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         ndk {
@@ -37,7 +37,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:25.3.1"
     compile 'com.google.android.gms:play-services-auth:+'
     compile "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
AppCompat updated from 23.0.1 to 25.3.1
compileSdkVersion from 23 to 25
targetSdkVersion from 22 to 25
buildToolsVersion from 23.0.3 to 25.0.3

Closes #237 