### PR TITLE
Use prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "url": "https://github.com/devfd/react-native-google-signin/issues"
   },
   "peerDependencies": {
-    "react": ">=15.4.0",
-    "react-native": ">=0.40"
+    "react": ">=15.4.0 || ^16.0.0-alpha",
+    "react-native": ">=0.40",
+    "prop-types": "^15.5.10"
   },
   "rnpm": {
     "ios": {

--- a/src/GoogleSignin.android.js
+++ b/src/GoogleSignin.android.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   View,

--- a/src/GoogleSignin.ios.js
+++ b/src/GoogleSignin.ios.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import {
   View,


### PR DESCRIPTION
Use prop-types npm. Accessing React.PropTypes is no longer supported and will be removed completely in React 16.