### PR TITLE
fixed header search path for use with CxxBridge

### DIFF
--- a/ios/RNGoogleSignin.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleSignin.xcodeproj/project.pbxproj
@@ -226,7 +226,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/**",
+					"${SRCROOT}/../../../ios/RNGoogleSignin",
+					"${SRCROOT}/../../../ios/GoogleSdk",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -244,7 +245,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/**",
+					"${SRCROOT}/../../../ios/RNGoogleSignin",
+					"${SRCROOT}/../../../ios/GoogleSdk",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This fixes an issue described here https://github.com/facebook/react-native/issues/14326 or here https://github.com/evollu/react-native-fcm/issues/593.

Basically when using CxxBridge I received the error 'limits' file not found, so I updated the header search paths like described here https://developers.facebook.com/bugs/111079162900447