### PR TITLE
Update ios-guide to use correct pod

### DIFF
--- a/ios-guide.md
+++ b/ios-guide.md
@@ -7,7 +7,7 @@ Includes Google Sign-In SDK v4.0.0
 #### Automatic
 
 - link the lib with `react-native link react-native-google-signin`
-- install the Google Signin SDK with [CocoaPods](https://cocoapods.org/) (add `pod 'Google/SignIn'` in your Podfile and run `pod install`)
+- install the Google Signin SDK with [CocoaPods](https://cocoapods.org/) (add `pod 'GoogleSignIn'` in your Podfile and run `pod install`)
 
 #### Manual
 


### PR DESCRIPTION
Process to repeat warning:

* Add `pod 'Google/SignIn` to `ios/Podfile`
* `$ pod install` from command line
* Get warning `[!] Google has been deprecated`

To fix:

* Change `pod 'Google/SignIn'` to `pod 'GoogleSignIn`